### PR TITLE
Upgrade to Core24

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,16 +41,16 @@ parts:
     plugin: meson
     parse-info: [usr/share/metainfo/com.github.huluti.Curtail.appdata.xml]
     meson-parameters:
-      - --prefix=/usr
+      - --prefix=/snap/curtail/current/usr
       - --buildtype=release
     override-pull: |
       craftctl default
       sed -e 's|Icon=com.github.huluti.Curtail|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/com.github.huluti.Curtail.svg|' -i data/com.github.huluti.Curtail.desktop.in
-    #override-build: |
-      #craftctl default
-      #sed -e '1c#!/usr/bin/env python3' -i ${CRAFT_PART_INSTALL}/snap/curtail/current/usr/bin/curtail
-    #organize:
-      #snap/curtail/current/usr: usr
+    override-build: |
+      craftctl default
+      sed -e '1c#!/usr/bin/env python3' -i ${CRAFT_PART_INSTALL}/snap/curtail/current/usr/bin/curtail
+    organize:
+      snap/curtail/current/usr: usr
 
   oxipng:
     source: https://github.com/shssoichiro/oxipng.git

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,9 +8,6 @@ platforms:
   amd64:
   arm64:
 
-#environment:
-  #XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
-
 slots:
   curtail:
     interface: dbus
@@ -23,7 +20,6 @@ apps:
     extensions: [gnome]
     environment:
       PYTHONPATH: ${SNAP}/usr/lib/python3/dist-packages:$PYTHONPATH
-      DISABLE_X11: 1
     plugs:
       - home
       - network
@@ -67,7 +63,6 @@ parts:
       - pngquant
       - scour
       - jpegoptim
-      #- xkb-data
     prime:
       - usr/lib/*/libimagequant*
       - usr/lib/python3
@@ -78,4 +73,3 @@ parts:
       - usr/bin/pngquant
       - usr/lib/*/libpng*
       - usr/lib/*/libjpeg*
-      #- usr/share/X11/xkb

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,6 +8,9 @@ platforms:
   amd64:
   arm64:
 
+environment:
+  XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
+
 slots:
   curtail:
     interface: dbus
@@ -20,7 +23,6 @@ apps:
     extensions: [gnome]
     environment:
       PYTHONPATH: ${SNAP}/usr/lib/python3/dist-packages:$PYTHONPATH
-      XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
     plugs:
       - home
       - network
@@ -39,16 +41,16 @@ parts:
     plugin: meson
     parse-info: [usr/share/metainfo/com.github.huluti.Curtail.appdata.xml]
     meson-parameters:
-      - --prefix=/snap/curtail/current/usr
+      - --prefix=/usr
       - --buildtype=release
     override-pull: |
       craftctl default
       sed -e 's|Icon=com.github.huluti.Curtail|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/com.github.huluti.Curtail.svg|' -i data/com.github.huluti.Curtail.desktop.in
-    override-build: |
-      craftctl default
-      sed -e '1c#!/usr/bin/env python3' -i ${CRAFT_PART_INSTALL}/snap/curtail/current/usr/bin/curtail
-    organize:
-      snap/curtail/current/usr: usr
+    #override-build: |
+      #craftctl default
+      #sed -e '1c#!/usr/bin/env python3' -i ${CRAFT_PART_INSTALL}/snap/curtail/current/usr/bin/curtail
+    #organize:
+      #snap/curtail/current/usr: usr
 
   oxipng:
     source: https://github.com/shssoichiro/oxipng.git

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,8 +8,8 @@ platforms:
   amd64:
   arm64:
 
-environment:
-  XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
+#environment:
+  #XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
 
 slots:
   curtail:
@@ -23,6 +23,7 @@ apps:
     extensions: [gnome]
     environment:
       PYTHONPATH: ${SNAP}/usr/lib/python3/dist-packages:$PYTHONPATH
+      DISABLE_X11: 1
     plugs:
       - home
       - network
@@ -66,7 +67,7 @@ parts:
       - pngquant
       - scour
       - jpegoptim
-      - xkb-data
+      #- xkb-data
     prime:
       - usr/lib/*/libimagequant*
       - usr/lib/python3
@@ -77,4 +78,4 @@ parts:
       - usr/bin/pngquant
       - usr/lib/*/libpng*
       - usr/lib/*/libjpeg*
-      - usr/share/X11/xkb
+      #- usr/share/X11/xkb

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,6 +20,7 @@ apps:
     extensions: [gnome]
     environment:
       PYTHONPATH: ${SNAP}/usr/lib/python3/dist-packages:$PYTHONPATH
+      XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
     plugs:
       - home
       - network
@@ -63,6 +64,7 @@ parts:
       - pngquant
       - scour
       - jpegoptim
+      - xkb-data
     prime:
       - usr/lib/*/libimagequant*
       - usr/lib/python3
@@ -73,3 +75,4 @@ parts:
       - usr/bin/pngquant
       - usr/lib/*/libpng*
       - usr/lib/*/libjpeg*
+      - usr/share/X11/xkb

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,13 +1,12 @@
 name: curtail
-base: core22
+base: core24
 adopt-info: curtail
 grade: stable
 confinement: strict
 compression: lzo
-architectures:
-  - build-on: amd64
-  - build-on: armhf
-  - build-on: arm64
+platforms:
+  amd64:
+  arm64:
 
 slots:
   curtail:
@@ -56,8 +55,6 @@ parts:
     source-depth: 1
     after: [curtail]
     plugin: rust
-    build-packages:
-      - cargo
 
   deps:
     after: [oxipng]
@@ -72,4 +69,7 @@ parts:
       - usr/bin/dh_scour
       - usr/bin/jpegoptim
       - usr/bin/scour
+      - usr/share/scour
       - usr/bin/pngquant
+      - usr/lib/*/libpng*
+      - usr/lib/*/libjpeg*


### PR DESCRIPTION
Upgrade snap to core24 to allow building newer/latest versions of curtail, also done are few minor sundry fixes with dependencies of curtail.
P.S. armhf support is dropped.
Only arm64 & amd64 will be supported going forward.

Solves #2 